### PR TITLE
Style fixes

### DIFF
--- a/imports/ui/common/BategoryContentCard.jsx
+++ b/imports/ui/common/BategoryContentCard.jsx
@@ -5,7 +5,10 @@ import styled from 'styled-components';
 
 const BategoriesVisitLabelContainer = styled.div`
     display: grid;
-    grid-template-columns: minmax(min-content, max-content) minmax(min-content, max-content);
+    grid-template-columns: minmax(min-content, max-content) minmax(
+            min-content,
+            max-content
+        );
     align-items: start;
     padding: 0 0 24px 24px;
     margin: 0;
@@ -22,7 +25,7 @@ const BategoriesVisitLabel = styled.p`
 
     font-size: 16px;
     line-height: 20px;
-    color: #FF325A;
+    color: #ff325a;
 
     opacity: 0;
     margin: 0;
@@ -69,31 +72,32 @@ const BategoryCardContainerWrapper = styled.div`
 
     &:hover ${BategoriesVisitLabel} {
         opacity: 1;
-    };
+    }
 
     &:hover ${BategoriesVisitLabelIcon} {
         opacity: 1;
-    };
+    }
 
     @media (hover: none) {
         /* on devices that do not have a pointer, don't have hover effects */
-        :hover{
+        :hover {
             /* leaving it for now because it actually looks kind of nice when you tap through to another site and then come back */
             /* background: none; */
-        };
-    };
+        }
+    }
 
     @media (max-width: 768px) {
         max-height: 300px;
-    };
+    }
 `;
 
 const BategoryCardContainer = styled.a`
     width: 100%;
     height: 100%;
     border-radius: 48px;
-    background-color: #FFFFFF;
-    box-shadow: 0 1px 2px 0 rgba(0,0,0,0.1), 0 12px 16px 0 rgba(0,0,0,0.06);
+    background-color: #ffffff;
+    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.1),
+        0 12px 16px 0 rgba(0, 0, 0, 0.06);
 
     text-decoration: none;
 
@@ -108,7 +112,7 @@ const BategoryCardContainer = styled.a`
 
     @media (max-width: 768px) {
         max-height: 300px;
-    };
+    }
 `;
 
 const BategoriesCardImage = styled.div`
@@ -157,7 +161,7 @@ const BategoriesCardTextTitle = styled.h3`
     font-size: 18px;
     line-height: 23px;
 
-    color: #9B9B9B;
+    color: #9b9b9b;
 
     text-decoration: none;
     padding: 24px 24px 4px 24px;
@@ -165,9 +169,9 @@ const BategoriesCardTextTitle = styled.h3`
 
     border-radius: 48px;
 
-    @media(max-width: 768px) {
+    @media (max-width: 768px) {
         hyphens: auto;
-    };
+    }
 `;
 
 const BategoriesCardTextBody = styled.p`
@@ -185,20 +189,16 @@ const BategoriesCardTextBody = styled.p`
     padding: 0 24px 4px 24px;
     margin: 0;
 
-    @media(max-width: 768px) {
+    @media (max-width: 768px) {
         hyphens: auto;
-    };
+    }
 `;
 
-export default (props) => {
+export default props => {
     return (
-        <BategoryCardContainerWrapper
-            key={props.contentName}>
-            <BategoryCardContainer
-                target="_blank"
-                href={props.urlLink}>
-                <BategoriesCardImage
-                    imgSrcName={props.imageLink} />
+        <BategoryCardContainerWrapper key={props.contentName}>
+            <BategoryCardContainer target="_blank" href={props.urlLink}>
+                <BategoriesCardImage imgSrcName={props.imageLink} />
 
                 <BategoriesCardTextContainer>
                     <BategoriesCardTextContentContainer>
@@ -210,16 +210,12 @@ export default (props) => {
                         </BategoriesCardTextBody>
                     </BategoriesCardTextContentContainer>
                     <BategoriesVisitLabelContainer>
-
-                        <BategoriesVisitLabel>
-                            Visit
-                        </BategoriesVisitLabel>
+                        <BategoriesVisitLabel>Visit</BategoriesVisitLabel>
 
                         <BategoriesVisitLabelIcon />
-
                     </BategoriesVisitLabelContainer>
                 </BategoriesCardTextContainer>
             </BategoryCardContainer>
         </BategoryCardContainerWrapper>
-    )
-}
+    );
+};

--- a/imports/ui/common/BategoryContentCard.jsx
+++ b/imports/ui/common/BategoryContentCard.jsx
@@ -63,10 +63,9 @@ const BategoryCardContainerWrapper = styled.div`
     border-radius: 52px;
 
     &:hover {
-        background:
-            linear-gradient(90deg, #FF7A2C 0%, #FF5F80 50.51%, #CD62FF 100%);
-        box-shadow: 0 6px 12px 0 rgba(255,50,90,0.2);
-    };
+        background-color: #ff325a;
+        box-shadow: 0 6px 12px 0 rgba(255, 50, 90, 0.2);
+    }
 
     &:hover ${BategoriesVisitLabel} {
         opacity: 1;

--- a/imports/ui/pages/FeaturedDetailPage/FeaturedPageContentSection.jsx
+++ b/imports/ui/pages/FeaturedDetailPage/FeaturedPageContentSection.jsx
@@ -14,13 +14,13 @@ const ContentSectionBackgroundWrapper = styled.div`
     padding: 0;
     margin: 0;
     /* 50% is at the (984px / 2) = 492 mark, so we need to add (718px - (984px / 2)) = 266px and 24px of padding = 290px*/
-    background: linear-gradient(90deg, #FFF calc(50% + 290px), #F2F2F2 50%);
+    background: linear-gradient(90deg, #fff calc(50% + 290px), #f2f2f2 50%);
 
-    @media(max-width: 1030px) {
+    @media (max-width: 1030px) {
         padding: 0 24px;
 
-        background: #FFF;
-    };
+        background: #fff;
+    }
 `;
 
 const ContentSectionWrapper = styled.div`
@@ -31,7 +31,6 @@ const ContentSectionWrapper = styled.div`
 `;
 
 const ContentSectionContainer = styled.div`
-
     /*    This is what this grid looks like:    */
     /*                                          */
     /*    |-------------[TITLE]-------------|   */
@@ -55,7 +54,7 @@ const ContentSectionContainer = styled.div`
     grid-column-gap: 0;
     grid-row-gap: 0;
 
-    @media(max-width: 1030px) {
+    @media (max-width: 1030px) {
         grid-template-columns: [content-start] auto [content-end];
         grid-template-rows: [title-start] auto [title-end body-start] auto [body-end credit-start] auto [credit-end];
     }
@@ -116,8 +115,8 @@ const FeaturedContentLinkButton = styled.a`
     height: 40px;
     width: 168px;
     border-radius: 10px;
-    background-color: #FFFFFF;
-    box-shadow: 0 2px 4px 0 rgba(0,0,0,0.1);
+    background-color: #ffffff;
+    box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.1);
 
     text-decoration: none;
 
@@ -139,10 +138,10 @@ const FeaturedContentLinkButton = styled.a`
     justify-content: center;
 
     :hover {
-        box-shadow: 0 4px 6px 0 rgba(0,0,0,0.1);
-    };
+        box-shadow: 0 4px 6px 0 rgba(0, 0, 0, 0.1);
+    }
 
-    @media(max-width: 1030px) {
+    @media (max-width: 1030px) {
         /* temporary solution to make button more visible on mobile */
         /* border: 2px solid #FE5677; */
 
@@ -154,7 +153,7 @@ const FeaturedContentLinkButton = styled.a`
         &:last-child {
             margin-top: 40px;
         }
-    };
+    }
 `;
 
 const FeaturedContentLinkButtonText = styled.p`
@@ -163,7 +162,7 @@ const FeaturedContentLinkButtonText = styled.p`
     font-weight: 800;
     font-style: normal;
 
-    color: #4A4A4A;
+    color: #4a4a4a;
 
     font-size: 16px;
     line-height: 20px;
@@ -196,7 +195,7 @@ export const FeaturedContentBodyParagraphLinkText = styled.a`
     font-weight: 800;
     font-style: normal;
 
-    color: #4A4A4A;
+    color: #4a4a4a;
 
     text-decoration: none;
 `;
@@ -216,7 +215,7 @@ export const FeaturedContentBodyImage = styled.div`
     position: relative;
 
     :before {
-        content: "";
+        content: '';
         /* 202px (width of grey column) - 84px (width of SVG image) = 118px offset */
         right: 119px;
         top: 0;
@@ -232,7 +231,7 @@ export const FeaturedContentBodyImage = styled.div`
     }
 
     :after {
-        content: "";
+        content: '';
         right: 119px;
         bottom: 0;
 
@@ -248,7 +247,7 @@ export const FeaturedContentBodyImage = styled.div`
         margin-bottom: -84px;
     }
 
-    @media(max-width: 1030px) {
+    @media (max-width: 1030px) {
         :before {
             display: none;
         }
@@ -308,7 +307,7 @@ const FeaturedContentAuthorName = styled.p`
     font-weight: 800;
     font-style: normal;
 
-    color: #FE5677;
+    color: #fe5677;
 
     font-size: 16px;
     line-height: 20px;
@@ -329,20 +328,26 @@ const FeaturedContentAuthorNameDate = styled.p`
     line-height: 20px;
 `;
 
-export default (props) => {
+export default props => {
     return (
         <>
             <ContentSectionBackgroundWrapper>
                 <ContentSectionWrapper>
                     <ContentSectionContainer>
-
                         <FeaturedContentTitleAndSubtitleContainer>
-                            <FeaturedContentTitle>{props.title}</FeaturedContentTitle>
-                            <FeaturedContentSubTitle>{props.subtitle}</FeaturedContentSubTitle>
+                            <FeaturedContentTitle>
+                                {props.title}
+                            </FeaturedContentTitle>
+                            <FeaturedContentSubTitle>
+                                {props.subtitle}
+                            </FeaturedContentSubTitle>
                         </FeaturedContentTitleAndSubtitleContainer>
 
                         <FeaturedContentBodyContainer>
-                            <FeaturedContentLinkButton target="_blank" href={props.link}>
+                            <FeaturedContentLinkButton
+                                target="_blank"
+                                href={props.link}
+                            >
                                 <FeaturedContentLinkButtonText>
                                     Visit site
                                 </FeaturedContentLinkButtonText>
@@ -351,39 +356,61 @@ export default (props) => {
                             {/* BEGINNING OF BODY CONTENT THAT CAN BE PULLED IN THROUGH CMS */}
 
                             <Switch>
-                                <Route path="/sky-folk"
-                                    render={props => <SkyFolkContent {...props} />} />
-                                <Route path="/internet-archive"
-                                    render={props => <InternetArchiveContent {...props} />} />
-                                <Route path="/indizr"
-                                    render={props => <IndizrContent {...props} />} />
-                                <Route path="/changelog"
-                                    render={props => <ChangelogContent {...props} />} />
+                                <Route
+                                    path="/sky-folk"
+                                    render={props => (
+                                        <SkyFolkContent {...props} />
+                                    )}
+                                />
+                                <Route
+                                    path="/internet-archive"
+                                    render={props => (
+                                        <InternetArchiveContent {...props} />
+                                    )}
+                                />
+                                <Route
+                                    path="/indizr"
+                                    render={props => (
+                                        <IndizrContent {...props} />
+                                    )}
+                                />
+                                <Route
+                                    path="/changelog"
+                                    render={props => (
+                                        <ChangelogContent {...props} />
+                                    )}
+                                />
                             </Switch>
 
                             {/* END OF BODY CONTENT THAT CAN BE PULLED IN THROUGH CMS */}
 
-                            <FeaturedContentLinkButton target="_blank" href={props.link}>
+                            <FeaturedContentLinkButton
+                                target="_blank"
+                                href={props.link}
+                            >
                                 <FeaturedContentLinkButtonText>
                                     Visit site
                                 </FeaturedContentLinkButtonText>
                             </FeaturedContentLinkButton>
-
                         </FeaturedContentBodyContainer>
 
                         <FeaturedContentCreditContainer>
                             <FeaturedContentBorderBox />
                             <FeaturedContentCreditTextContainer>
                                 <FeaturedContentAuthorNameBy>
-                                    By <FeaturedContentAuthorName>{props.author}</FeaturedContentAuthorName>
+                                    By{' '}
+                                    <FeaturedContentAuthorName>
+                                        {props.author}
+                                    </FeaturedContentAuthorName>
                                 </FeaturedContentAuthorNameBy>
-                                <FeaturedContentAuthorNameDate>{props.date}</FeaturedContentAuthorNameDate>
+                                <FeaturedContentAuthorNameDate>
+                                    {props.date}
+                                </FeaturedContentAuthorNameDate>
                             </FeaturedContentCreditTextContainer>
                         </FeaturedContentCreditContainer>
-
                     </ContentSectionContainer>
                 </ContentSectionWrapper>
             </ContentSectionBackgroundWrapper>
         </>
-    )
-}
+    );
+};

--- a/imports/ui/pages/FeaturedDetailPage/FeaturedPageContentSection.jsx
+++ b/imports/ui/pages/FeaturedDetailPage/FeaturedPageContentSection.jsx
@@ -90,19 +90,10 @@ const FeaturedContentTitle = styled.h1`
     line-height: 60px;
     letter-spacing: -0.6px;
 
-    color: #939393;
+    color: #ff325a;
 
     margin: 0;
     padding: 49px 0 0 0;
-
-    background: -webkit-linear-gradient(360deg, #FF7A2C 0%, #FF5F80 50.51%, #CD62FF 100%);
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-
-    &::selection {
-        -webkit-text-fill-color: #FFFFFF;
-    }
 `;
 
 const FeaturedContentSubTitle = styled.h2`

--- a/imports/ui/pages/HomePage/FeaturedSection.jsx
+++ b/imports/ui/pages/HomePage/FeaturedSection.jsx
@@ -164,7 +164,7 @@ const CollectionCardContainerWrapper = styled.div`
     max-width: 984px;
     width: 100%;
 
-    min-height: 336px;
+    min-height: 328px;
     height: 100%;
 
     grid-column: span 2;

--- a/imports/ui/pages/HomePage/FeaturedSection.jsx
+++ b/imports/ui/pages/HomePage/FeaturedSection.jsx
@@ -64,12 +64,8 @@ const FeaturedCardContainerWrapper = styled.div`
     border-radius: 52px;
 
     &:hover {
-        background: linear-gradient(
-            90deg,
-            #ff7a2c 0%,
-            #ff5f80 50.51%,
-            #cd62ff 100%
-        );
+        background-color: #ff325a;
+
         box-shadow: 0 6px 12px 0 rgba(255, 50, 90, 0.2);
     }
 `;
@@ -184,12 +180,7 @@ const CollectionCardContainerWrapper = styled.div`
     border-radius: 52px;
 
     &:hover {
-        background: linear-gradient(
-            90deg,
-            #ff7a2c 0%,
-            #ff5f80 50.51%,
-            #cd62ff 100%
-        );
+        background-color: #ff325a;
         box-shadow: 0 6px 12px 0 rgba(255, 50, 90, 0.2);
     }
 

--- a/imports/ui/pages/HomePage/HeaderSection.jsx
+++ b/imports/ui/pages/HomePage/HeaderSection.jsx
@@ -6,7 +6,7 @@ import Header from '../../common/Header';
 import { NavLink } from 'react-router-dom';
 
 const Container = styled.div`
-    min-height: 220px;
+    min-height: 182px;
     width: 100%;
     z-index: 3;
 
@@ -40,7 +40,7 @@ const LogoWordMark = styled(NavLink)`
     background-size: cover;
     background-position: center;
 
-    height: 60px;
+    height: 59px;
     width: 217px;
 
     @media (max-width: 1030px) {

--- a/imports/ui/pages/HomePage/index.jsx
+++ b/imports/ui/pages/HomePage/index.jsx
@@ -13,10 +13,10 @@ const ContentSectionContainer = styled.div`
 `;
 
 const GradientContainerTop = styled.div`
-    background: linear-gradient(
-        180deg,
-        rgba(50, 106, 255, 0.14) 0.07%,
-        rgba(255, 50, 207, 0) 100%
+    background-image: linear-gradient(
+        to bottom,
+        rgba(50, 106, 255, 0.14) 0%,
+        rgba(255, 50, 207, 0)
     );
 
     position: absolute;


### PR DESCRIPTION
A few small changes to reflect the latest design:

### Featured article header colour is now solid instead of gradient
<img width="616" alt="Screen Shot 2019-07-25 at 8 16 58 PM" src="https://user-images.githubusercontent.com/10648471/61923509-3af9bf80-af19-11e9-8d96-0a484e6a3744.png">

### Hover border colour is now solid instead of gradient
<img width="529" alt="Screen Shot 2019-07-25 at 8 18 06 PM" src="https://user-images.githubusercontent.com/10648471/61923554-5b297e80-af19-11e9-8833-b4abdb2f682c.png">
It's still a hacky solution and not scale-animated like it should be, but I'll come back to this later (not super high priority right now). Animating borders is actually [a pretty tough CSS problem](https://css-tricks.com/animating-border/), which is kind of ridiculous 😭

### Wordmark top spacing fixed (there was too much padding before)
<img width="882" alt="Screen Shot 2019-07-25 at 8 19 24 PM" src="https://user-images.githubusercontent.com/10648471/61923597-89a75980-af19-11e9-96a8-2bd94033183e.png">
I'm not sure why the colour looks so different in Zeplin and in my browser, but I'll chalk it up to how each application renders colours, because the values in the gradient are identical.